### PR TITLE
initial partial zsh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,24 @@ redshift_admin_dependencies                 redshift_columns
 ```
 
 
-### Installation
+### Installation (bash)
 This script can be installed by moving it to your home directory (as a dotfile), then sourcing it in your `~/.bash_profile` file.
 
 ```
 curl https://raw.githubusercontent.com/fishtown-analytics/dbt-completion.bash/master/dbt-completion.bash > ~/.dbt-completion.bash
 echo 'source ~/.dbt-completion.bash' >> ~/.bash_profile
+```
+
+### Installation (zsh)
+The z shell requires a bit more work, you'll also want to automatically load `compinit` and `bashcompinit` if they are not already loaded.
+
+This makes use of zsh's ability to import bash completion scripts and use them, as long as they're script-compatible.
+
+```
+curl https://raw.githubusercontent.com/fishtown-analytics/dbt-completion.bash/master/dbt-completion.bash > ~/.dbt-completion.bash
+echo 'autoload -U +X compinit && compinit' >> ~/.zshrc
+echo 'autoload -U +X bashcompinit && bashcompinit' >> ~/.zshrc
+echo 'source ~/.dbt-completion.bash' >> ~/.zshrc
 ```
 
 ### Bash Completion
@@ -39,3 +51,5 @@ $ brew install bash-completion
 This script uses the manifest (assumed to be at `target/manifest.json`) to _quickly_ provide a list of existing selectors. As such, a dbt resource must be compiled before it will be available for tab completion. In the future, this script should use dbt directly to parse the project directory and generate possible selectors. Until then, brand new models/sources/tags/packages will not be displayed in the tab complete menu.
 
 This script was tested on macOS using bash 4.4.23. It's very likely that this script will not work as expected on other operating systems or in other shells. If you're interested in helping make this script work on another platform, please open an issue!
+
+On zsh, when you want to use the `project.folder.*` notation, you may have to prefix with a quote, as otherwise you'll get autocompleted to something like `dbt compile -m project.folder.*`, and zsh will try to glob, find no matches, and throw an error.

--- a/dbt-completion.bash
+++ b/dbt-completion.bash
@@ -176,7 +176,7 @@ _get_project_root() {
 # Core bash completion logic
 _complete_it() {
     # Requires bash-completion, used to handle ':' chars in args
-    if [[ $(type -t _get_comp_words_by_ref) == 'function' ]] ; then
+    if [[ $(type _get_comp_words_by_ref) =~ 'function' ]] ; then
         local cur
         _get_comp_words_by_ref -n : cur
     fi
@@ -209,7 +209,7 @@ _complete_it() {
         fi
 
         # Requires bash-completion, used to handle ':' chars in args
-        if [[ $(type -t __ltrim_colon_completions ) == 'function' ]] ; then
+        if [[ $(type __ltrim_colon_completions ) =~ 'function' ]] ; then
             __ltrim_colon_completions "$cur"
         fi
     fi


### PR DESCRIPTION
Add zsh support for people like me. I'd definitely rather go back to this and write up separate native zsh support when I have time, for now this just uses `bashcompinit` (and fuzzy comparison instead of the not-allowed-on-zsh `type -t` flag).