### PR TITLE
Fix support for Linux (support GNU version of `seq`)

### DIFF
--- a/dbt-completion.bash
+++ b/dbt-completion.bash
@@ -121,7 +121,7 @@ _get_last_flag() {
     arg_list=("$@")
 
     first_flag=""
-    for i in $(seq $arg_index 0); do
+    for i in $(seq $arg_index -1 0); do
         arg=${arg_list[$i]}
         if [[ $arg == -* ]] ; then
             first_flag=$arg


### PR DESCRIPTION
The Mac version of seq supports omitting negative increment, whereas the
GNU version defaults to 1. Thus, with the GNU version of seq an empty list
is returned and no iteration takes place. Specifying a negative increment
works with both versions.

GNU version
```
~ $ for i in $(seq 2 0); do echo $i; done
~ $ for i in $(seq 2 -1 0); do echo $i; done
2
1
0
```

Mac version
```
~ $ for i in $(seq 2 0); do echo $i; done
2
1
0
~ $ for i in $(seq 2 -1 0); do echo $i; done
2
1
0
```