### PR TITLE
Add tab completion for the dbtf alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 This script adds autocompletion to the [dbt](https://www.getdbt.com/) CLI. Once installed, users can tab-complete model, tag, source, and package selectors to node selection flags like `--select` and `--exclude`. Need a refresher on resource selection? Check out [the docs](https://docs.getdbt.com/reference/node-selection/syntax).
 
-The zsh script (`_dbt`) supports both **dbt Core** and **Fusion**. It auto-detects which binary is on your `$PATH` and uses the appropriate completion backend — no configuration needed:
+The zsh script (`_dbt`) supports both **dbt Core** and **Fusion**, including the `dbtf` alias created by the Fusion installer. It auto-detects which binary is on your `$PATH` and uses the appropriate completion backend — no configuration needed:
 
 - **dbt Core**: uses Click's built-in runtime completion
-- **Fusion**: uses `dbt completions zsh` (clap_complete), cached by binary mtime for near-instant completions
+- **Fusion** (`dbt` and `dbtf`): uses `dbt completions zsh` (clap_complete), cached by binary mtime for near-instant completions
 
 Model and selector completions from `manifest.json` work the same way for both.
 

--- a/_dbt
+++ b/_dbt
@@ -1,4 +1,4 @@
-#compdef dbt
+#compdef dbt dbtf
 
 # OVERVIEW
 #   Adds autocompletion to dbt CLI by:
@@ -283,9 +283,10 @@ _dbt_detect_type() {
 
 # For dbt-fusion: source the clap_complete-generated zsh script (cached by binary mtime),
 # then delegate to the _dbt function it defines.
+# Accepts an optional explicit binary path (used when completing the dbtf alias).
 _dbt_fusion_complete() {
-    local bin_path
-    bin_path=$(command -v dbt) || return 1
+    local bin_path="${1:-$(command -v dbt)}"
+    [[ -z "$bin_path" ]] && return 1
 
     local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}"
     local script_cache="$cache_dir/dbt_fusion_completions.zsh"
@@ -294,7 +295,7 @@ _dbt_fusion_complete() {
 
     if [[ ! -f "$script_cache" ]] || [[ "$(cat "$key_cache" 2>/dev/null)" != "$current_key" ]]; then
         mkdir -p "$cache_dir"
-        dbt completions zsh > "$script_cache" 2>/dev/null
+        "$bin_path" completions zsh > "$script_cache" 2>/dev/null
         printf '%s' "$current_key" > "$key_cache"
     fi
 
@@ -356,13 +357,10 @@ _dbt_core_complete() {
 
 # Main function
 # Auto-detects dbt-core vs dbt-fusion and routes to the appropriate completion backend.
+# For the dbtf alias (always Fusion), the binary path is resolved from the alias value.
 # Manifest-based model/selector completions are applied for both.
 _dbt() {
     local ret=1
-
-    if ! command -v dbt &> /dev/null; then
-        return 1
-    fi
 
     # Manifest-based model/selector completions apply regardless of binary type
     local prev_word=""
@@ -381,13 +379,24 @@ _dbt() {
             ;;
     esac
 
+    # dbtf is always Fusion; resolve the binary from the alias value directly
+    if [[ "$service" == "dbtf" ]]; then
+        local dbtf_bin="${aliases[dbtf]}"
+        _dbt_fusion_complete "$dbtf_bin"
+        return $?
+    fi
+
+    if ! command -v dbt &> /dev/null; then
+        return 1
+    fi
+
     local dbt_type
     dbt_type=$(_dbt_detect_type)
 
     if [[ "$dbt_type" == "fusion" ]]; then
-        _dbt_fusion_complete "$@"
+        _dbt_fusion_complete
     else
-        _dbt_core_complete "$@"
+        _dbt_core_complete
     fi
     return $?
 }


### PR DESCRIPTION
## What

The Fusion installer creates a `dbtf` shell alias pointing to the Fusion binary (`alias dbtf=~/.local/bin/dbt`). This PR extends the `_dbt` completion script to cover that alias.

## How

- `#compdef dbt dbtf` — registers the script for both commands
- When `$service == "dbtf"`, skip auto-detection and resolve the binary path directly from `$aliases[dbtf]`, always routing to the Fusion completion path
- `_dbt_fusion_complete` now accepts an optional explicit binary path for this case

No configuration needed — works automatically for anyone who installed Fusion via the installer.